### PR TITLE
Remove duplicate writeHead call in Http server

### DIFF
--- a/src/xmpp/XMPPMITMManager.ts
+++ b/src/xmpp/XMPPMITMManager.ts
@@ -136,7 +136,6 @@ export class XMPPMITMManager {
 
                 res.writeHead(response.status)
 
-                res.writeHead(response.status)
                 if(req.url?.startsWith('/api/v1/config/player') && response.status === 200) {
                     // Rewrite affinity data
                     const data = JSON.parse(text) satisfies PlayerConfigAffinities


### PR DESCRIPTION
The HTTP server was calling `res.writeHead(response.status)` twice, which caused an error. This PR removes the unnecessary duplicate call, ensuring the response headers are set correctly.